### PR TITLE
Refactor turbine_long_term_gross_energy

### DIFF
--- a/operational_analysis/methods/turbine_long_term_gross_energy.py
+++ b/operational_analysis/methods/turbine_long_term_gross_energy.py
@@ -167,7 +167,6 @@ class TurbineLongTermGrossEnergy(object):
         # Log the completion of the run
         logger.info("Run completed")
     
-    @logged_method_call
     def setup_inputs(self):
         """
         Create and populate the data frame defining the simulation parameters.

--- a/test/int_turbine_long_term_gross_energy.py
+++ b/test/int_turbine_long_term_gross_energy.py
@@ -28,12 +28,12 @@ class TestPandasPrufPlantAnalysis(unittest.TestCase):
         check = np.ones_like(res)*1.35
         npt.assert_almost_equal(res/1000000, check, decimal=1)
 
-        # Test not-UQ case, mean value
+        # Test UQ case, mean value
         res_uq = self.analysis_uq._plant_gross.mean()
         check_uq = np.ones_like(res)*1.35
         npt.assert_almost_equal(res_uq/1000000, check_uq, decimal=1)
 
-        # Test not-UQ case, stdev
+        # Test UQ case, stdev
         res_std_uq = self.analysis_uq._plant_gross.std()
         check_std_uq = 0.05
         npt.assert_almost_equal(res_std_uq/1000000, check_std_uq, decimal=1)

--- a/test/int_turbine_long_term_gross_energy.py
+++ b/test/int_turbine_long_term_gross_energy.py
@@ -7,7 +7,7 @@ from operational_analysis.methods.turbine_long_term_gross_energy import TurbineL
 from examples.turbine_analysis.turbine_project import TurbineExampleProject
 
 
-class TestPandasPrufPlantAnalysis(unittest.TestCase):
+class TestLongTermGrossEnergy(unittest.TestCase):
 
     def setUp(self):
         np.random.seed(42)
@@ -18,19 +18,33 @@ class TestPandasPrufPlantAnalysis(unittest.TestCase):
         self.analysis = TurbineLongTermGrossEnergy(self.project, UQ = False)
         self.analysis.run(reanal_subset = ['erai', 'merra2', 'ncep2'], enable_plotting = False)
 
-        self.analysis_uq = TurbineLongTermGrossEnergy(self.project, UQ = True, num_sim = 100)
-        self.analysis_uq.run(reanal_subset = ['erai', 'merra2', 'ncep2'], enable_plotting = False)
-
     def test_longterm_gross_energy_results(self):
 
         # Test not-UQ case
         res = self.analysis._plant_gross
         check = np.ones_like(res)*1.35
         npt.assert_almost_equal(res/1000000, check, decimal=1)
+        
+    def tearDown(self):
+        pass
+
+
+class TestLongTermGrossEnergyUQ(unittest.TestCase):
+
+    def setUp(self):
+        np.random.seed(42)
+        # Set up data to use for testing (TurbineExampleProject)
+        self.project = TurbineExampleProject('./examples/turbine_analysis/data')
+        self.project.prepare()
+
+        self.analysis_uq = TurbineLongTermGrossEnergy(self.project, UQ = True, num_sim = 100)
+        self.analysis_uq.run(reanal_subset = ['erai', 'merra2', 'ncep2'], enable_plotting = False)
+
+    def test_longterm_gross_energy_results(self):
 
         # Test UQ case, mean value
         res_uq = self.analysis_uq._plant_gross.mean()
-        check_uq = np.ones_like(res)*1.35
+        check_uq = 1.35
         npt.assert_almost_equal(res_uq/1000000, check_uq, decimal=1)
 
         # Test UQ case, stdev
@@ -40,7 +54,6 @@ class TestPandasPrufPlantAnalysis(unittest.TestCase):
         
     def tearDown(self):
         pass
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
With this pull request I am demonstrating how to refactor the turbine long term gross energy class so the code is less repetitive. The major change I made was to remove all the "if UQ=True" code blocks from the class. I implemented this by changing the way UQ=False behaves, to make it look more like a monte-carlo simulation (with just three simulations, one for each reanalysis product). In service of this, I removed all the "_mc" instance variables in favor of an "_inputs" dataframe. Please check out "setup_inputs" to see how that works.

Additionally, I added some memoization to setup_daily_reanalysis_data. Memoization is a general technique that can speed up functions which are called repeatedly and do the same thing each time. Basically, each time the function is called with a new reanalysis product it stores the result in "self._setup_daily_reanalysis_data_memo", which is a dictionary where the keys are reanalysis product names. Then, the next time the function is called with the same reanalysis product name it can simply look up the answer in the memo dictionary instead of having to recompute it.

Hope this helps!